### PR TITLE
Using ovirt_auth module to authenticate with oVirt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+vault.yml

--- a/provision.yml
+++ b/provision.yml
@@ -14,6 +14,7 @@
 - name: Setup Loadbalancer Host
   hosts: loadbalancer
   become: yes
+  gather_facts: false
   roles:
     - role: dhcpd
       tags:

--- a/roles/boot-instances/tasks/main.yml
+++ b/roles/boot-instances/tasks/main.yml
@@ -1,10 +1,13 @@
+- name: Authenticate to oVirt
+  ovirt_auth:
+    username: "{{ rhv_username }}"
+    password: "{{ rhv_password }}"
+    url: "https://{{ rhv_hostname }}/ovirt-engine/api"
+    insecure: True
+
 - name: Startup (install) Bootstrap Node
   ovirt_vm:
-    auth:
-      username: "{{ rhv_username }}"
-      password: "{{ rhv_password }}"
-      url: "https://{{ rhv_hostname }}/ovirt-engine/api"
-      insecure: True
+    auth: "{{ ovirt_auth }}"
     name: "bootstrap.{{ base_domain }}"
     state: running
 
@@ -17,11 +20,7 @@
 
 - name: Startup (install) Master Nodes
   ovirt_vm:
-    auth:
-      username: "{{ rhv_username }}"
-      password: "{{ rhv_password }}"
-      url: "https://{{ rhv_hostname }}/ovirt-engine/api"
-      insecure: True
+    auth: "{{ ovirt_auth }}"
     name: "{{ item }}.{{ base_domain }}"
     state: running
   with_items:
@@ -40,11 +39,7 @@
 
 - name: Startup (install) Worker Nodes
   ovirt_vm:
-    auth:
-      username: "{{ rhv_username }}"
-      password: "{{ rhv_password }}"
-      url: "https://{{ rhv_hostname }}/ovirt-engine/api"
-      insecure: True
+    auth: "{{ ovirt_auth }}"
     name: "{{ item }}.{{ base_domain }}"
     state: running
   with_items:
@@ -60,3 +55,8 @@
   with_items:
     - "{{ groups[provision_group] }}"
   when: item is search("worker")
+
+- name: Revoke the SSO token
+  ovirt_auth:
+    state: absent
+    ovirt_auth: "{{ ovirt_auth }}"

--- a/roles/rhv/tasks/main.yml
+++ b/roles/rhv/tasks/main.yml
@@ -1,11 +1,15 @@
 ---
+- name: Authenticate to oVirt
+  ovirt_auth:
+    username: "{{ rhv_username }}"
+    password: "{{ rhv_password }}"
+    url: "https://{{ rhv_hostname }}/ovirt-engine/api"
+    insecure: True
+
+
 - name: Create VMs
   ovirt_vm:
-    auth:
-      username: "{{ rhv_username }}"
-      password: "{{ rhv_password }}"
-      url: "https://{{ rhv_hostname }}/ovirt-engine/api"
-      insecure: True
+    auth: "{{ ovirt_auth }}"
     state: stopped
     delete_protected: False
     name: "{{ item }}.{{ base_domain }}"
@@ -31,11 +35,7 @@
 
 - name: Get VM Facts
   ovirt_vm_facts:
-    auth:
-      username: "{{ rhv_username }}"
-      password: "{{ rhv_password }}"
-      url: "https://{{ rhv_hostname }}/ovirt-engine/api"
-      insecure: True
+    auth: "{{ ovirt_auth }}"
     fetch_nested: True
     nested_attributes: True
     pattern: name={{ item }}.{{ base_domain }} and cluster={{ rhv_cluster }}
@@ -67,11 +67,7 @@
 
 - name: Add Disks to VMs
   ovirt_disk:
-    auth:
-      username: "{{ rhv_username }}"
-      password: "{{ rhv_password }}"
-      url: "https://{{ rhv_hostname }}/ovirt-engine/api"
-      insecure: True
+    auth: "{{ ovirt_auth }}"
     name: "{{ item.0.name }}.{{ base_domain }}-{{ item.1.name }}"
     bootable: "{{ item.1.bootable }}"
     vm_name: "{{ item.0.name }}.{{ base_domain }}"
@@ -104,11 +100,7 @@
 
 - name: Add NICs to VMs
   ovirt_nic:
-    auth:
-      username: "{{ rhv_username }}"
-      password: "{{ rhv_password }}"
-      url: "https://{{ rhv_hostname }}/ovirt-engine/api"
-      insecure: True
+    auth: "{{ ovirt_auth }}"
     name: "{{ item.1.name }}"
     interface: "{{ item.1.interface }}"
     network: "{{ item.1.network }}"
@@ -123,11 +115,7 @@
 
 - name: Get VM NIC Facts
   ovirt_nic_facts:
-    auth:
-      username: "{{ rhv_username }}"
-      password: "{{ rhv_password }}"
-      url: "https://{{ rhv_hostname }}/ovirt-engine/api"
-      insecure: True
+    auth: "{{ ovirt_auth }}"
     name: eth0
     vm: "{{ item }}.{{ base_domain }}"
   register: ovirt_nic_facts_results
@@ -153,6 +141,11 @@
 - name: Debug host_mac_list
   debug:
     var: host_mac_list
+
+- name: Revoke the SSO token
+  ovirt_auth:
+    state: absent
+    ovirt_auth: "{{ ovirt_auth }}"
 
 #- name: Build VM/eth0 Results for DHCP
 #  set_fact:


### PR DESCRIPTION
This PR's purpose is threefold:
1) The main point is to use `ovirt_auth` module only once in `rhv` and `boot-isntances` roles. This way, we only obtain authentication token once in the beginning and after that, we just reuse it. It shortens the code and speeds up execution. I did not do the same in `rhv-retire` role, since there is only one task that authenticates with oVirt.

2) I added `vault.yml` to .gitignore file since the `provision.yml` playbook expects that user-created file to be in the repository root.

3) I added `gather_facts: false` to `Setup Loadbalancer Host` play. As far as I can tell, we don't use any gathered facts in the affected roles. Also, sometimes you want to run just a part of the playbook. Let's say you just want to create VMs in your engine. In that case, you run something like this:
```
ansible-playbook provision.yml --tags=rhv
```
If `gather_facts` in second play is set to `true`, the playbook might fail even though that creation of VMs was successful. The reason is that when user knows they'll be running only `--tags=rhv`, they might not set loadbalancer host that is required for `Setup Loadbalancer Host` play.