### PR TITLE
Adding possibility to add MAC address for VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following global variables will need to be modified (the default values are 
 |dhcp\_server\_subnet|IP Subnet used to configure dhcpd.conf|
 |load\_balancer\_ip|This IP address of your load balancer (the server that HAProxy will be installed on)|
 
-For the individual node configuration, be sure to update the hosts in the `pg` hostgroup. Several parameters will need to be changed for _each_ host including `ip`, `storage_domain` and `network`. Match up your RHV environment with the inventory file.
+For the individual node configuration, be sure to update the hosts in the `pg` hostgroup. Several parameters will need to be changed for _each_ host including `ip`, `storage_domain` and `network`. You can also specify `mac_address` for each of the VMs in its `network` section (if you don't, VMs will obtain their MAC address from cluster's MAC pool automatically). Match up your RHV environment with the inventory file.
 
 Under the `webserver` and `loadbalancer` group include the FQDN of each host. Also make sure you configure the `httpd_port` variable for the web server host. In this example, the web server that will serve up installation artifacts and load balancer (HAProxy) are the same host.
 

--- a/inventory-example.yml
+++ b/inventory-example.yml
@@ -36,6 +36,7 @@ all:
           - name: eth0
             network: lab
             interface: virtio
+            # mac_address: You can provide specific MAC address here
         master0:
           etcd_name: etcd-0
           ip: 172.16.10.151

--- a/roles/rhv/tasks/main.yml
+++ b/roles/rhv/tasks/main.yml
@@ -105,6 +105,7 @@
     interface: "{{ item.1.interface }}"
     network: "{{ item.1.network }}"
     profile: "{{ item.1.network }}"
+    mac_address: "{{ item.1.mac_address | default(omit) }}"
     vm: "{{ item.0.name }}.{{ base_domain }}"
   tags:
     - create_nics


### PR DESCRIPTION
This PR makes it possible to provide specific MAC address for each of the VMs. 
Use case: User already has set up their own MAC to IP mapping in DHCP and IP to FQDN mapping in DNS.