### PR TITLE
Installing packages needed by seboolean module

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -2,6 +2,8 @@
   yum:
     name:
       - haproxy
+      - libselinux-python
+      - libsemanage-python
     state: latest
 
 - name: Copy haproxy.cfg Template
@@ -19,7 +21,7 @@
     state: yes
     persistent: yes
 
-- name: Enable/Start httpd Service
+- name: Enable/Start haproxy Service
   systemd:
     name: haproxy
     state: started


### PR DESCRIPTION
I added installation of two packages to `haproxy` role. The reason is that those two packages are required to run `seboolean` module on the target machine. 