### PR TITLE
Enable required httpd ports in webserver installation

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -34,6 +34,13 @@
 - name: Restore SELinux Contexts in Document Root
   shell: restorecon -R /var/www/html
 
+- name: Enable webserver ports in firewall
+  firewalld:
+    port: "{{ httpd_port }}/tcp"
+    state: enabled
+    permanent: yes
+    immediate: yes
+
 - name: Enable/Start httpd Service
   systemd:
     name: httpd


### PR DESCRIPTION
Adding task to `httpd` role that enables required ports in firewall configuration. Maybe some of them are missing now (I may add them later), but AFAIK the port `22623` is supposed to serve additional ignition content.