### PR TITLE
Let port 6443 through firewall on loadbalancer

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -21,6 +21,18 @@
     state: yes
     persistent: yes
 
+- name: Enable proxied ports in firewall
+  firewalld:
+    port: "{{ item }}/tcp"
+    state: enabled
+    permanent: yes
+    immediate: yes
+  loop:
+    - 80
+    - 443
+    - 6443
+    - 22623
+
 - name: Enable/Start haproxy Service
   systemd:
     name: haproxy

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Restore SELinux Contexts in Document Root
   shell: restorecon -R /var/www/html
 
-- name: Enable webserver ports in firewall
+- name: Enable httpd port in firewall
   firewalld:
     port: "{{ httpd_port }}/tcp"
     state: enabled


### PR DESCRIPTION
So in my original PR regarding this, I though that port 22623 has to be accessible on load balancer. That's not really the case because master and worker node query that port on address api-int.<cluster_name>.<base_domain>, which should point to bootstrap. 

However, during step `openshift-install wait-for bootstrap-complete`, the installer queries port 6443 on address api.<cluster_name>.<base_domain>, which is pointing to load balancer. Therefore we need to have this port open there.